### PR TITLE
Add Unhealthy Error Text

### DIFF
--- a/src/Samhammer.AspNetCore.HealthChecks.Prtg.Test/PrtgResponseWriterTest.cs
+++ b/src/Samhammer.AspNetCore.HealthChecks.Prtg.Test/PrtgResponseWriterTest.cs
@@ -23,6 +23,19 @@ namespace Samhammer.AspNetCore.HealthChecks.Prtg.Test
         }
 
         [Fact]
+        public void BuildPrtgResponseObject_Unhealthy_ErrorText()
+        {
+            var healthReportEntry =
+                new HealthReportEntry(HealthStatus.Unhealthy, null, TimeSpan.Zero, null, null);
+            var healthReportEntries = new Dictionary<string, HealthReportEntry> { { "test", healthReportEntry } };
+            var healthReport = new HealthReport(healthReportEntries, TimeSpan.Zero);
+
+            var actual = PrtgResponseWriter.BuildPrtgResponseObject(healthReport);
+            actual.Error.Should().Be(1);
+            actual.Text.Should().BeEquivalentTo("test:\nUnhealthy");
+        }
+
+        [Fact]
         public void BuildPrtgResponseObject_Degraded()
         {
             var healthReportEntry =

--- a/src/Samhammer.AspNetCore.HealthChecks.Prtg/PrtgResponseWriter.cs
+++ b/src/Samhammer.AspNetCore.HealthChecks.Prtg/PrtgResponseWriter.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -33,8 +34,8 @@ namespace Samhammer.AspNetCore.HealthChecks.Prtg
             response.Error = report.Status == HealthStatus.Unhealthy ? 1 : 0;
 
             var errors = report.Entries
-                .Where(e => !string.IsNullOrWhiteSpace(e.Value.Description) || e.Value.Exception != null)
-                .Select(e => $"{e.Key}:\n{e.Value.Description}\n{e.Value.Exception}")
+                .Where(e => !string.IsNullOrWhiteSpace(e.Value.Description) || e.Value.Exception != null || e.Value.Status == HealthStatus.Unhealthy)
+                .Select(BuildErrorText)
                 .ToList();
 
             if (errors.Any())
@@ -50,6 +51,16 @@ namespace Samhammer.AspNetCore.HealthChecks.Prtg
             }
 
             return response;
+        }
+
+        private static string BuildErrorText(KeyValuePair<string, HealthReportEntry> entry)
+        {
+            if (!string.IsNullOrWhiteSpace(entry.Value.Description) || entry.Value.Exception != null)
+            {
+                return $"{entry.Key}:\n{entry.Value.Description}\n{entry.Value.Exception}";
+            }
+
+            return $"{entry.Key}:\n{entry.Value.Status}";
         }
     }
 }


### PR DESCRIPTION
If there is not an exception or a description on the HealthReportEntry,
build an error text which reports the name and Status.

Sample use case: The [Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore](https://www.nuget.org/packages/Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore)
sets neither the description nor sets an exception in some cases (i.e.
the database if offline). This causes a confusing message from PRTG
where it reports an error but then uses the default text "Everything is
fine :)".